### PR TITLE
Fix `Loader::addPlayer()` Crash when Player is created asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Once a fake player joins, you can chat or run commands on their behalf using:<br
 ## API Documentation
 ### Adding a fake player
 ```php
-Loader::addPlayer(FakePlayerInfo $info) : Player;
+Loader::addPlayer(FakePlayerInfo $info) : Promise;
 ```
 Fake players can be spawned in during runtime using `Loader::addPlayer()`. `FakePlayerInfo` consists of player identity and miscellaneous data and can be built easily using `FakePlayerInfoBuilder`.
 ```php

--- a/src/muqsit/fakeplayer/network/FakePlayerNetworkSession.php
+++ b/src/muqsit/fakeplayer/network/FakePlayerNetworkSession.php
@@ -6,16 +6,35 @@ namespace muqsit\fakeplayer\network;
 
 use muqsit\fakeplayer\network\listener\FakePlayerPacketListener;
 use muqsit\fakeplayer\network\listener\FakePlayerSpecificPacketListener;
+use pocketmine\network\mcpe\compression\Compressor;
 use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\network\mcpe\PacketBroadcaster;
+use pocketmine\network\mcpe\PacketSender;
 use pocketmine\network\mcpe\protocol\ClientboundPacket;
+use pocketmine\network\mcpe\protocol\PacketPool;
+use pocketmine\network\NetworkSessionManager;
+use pocketmine\player\Player;
+use pocketmine\promise\Promise;
+use pocketmine\promise\PromiseResolver;
+use pocketmine\Server;
+use ReflectionMethod;
+use ReflectionProperty;
 
 class FakePlayerNetworkSession extends NetworkSession{
+
+	/** @var PromiseResolver */
+	private $playerResolver;
 
 	/** @var FakePlayerPacketListener[] */
 	private $packet_listeners = [];
 
 	/** @var FakePlayerSpecificPacketListener|null */
 	private $specific_packet_listener;
+
+	public function __construct(Server $server, NetworkSessionManager $manager, PacketPool $packetPool, PacketSender $sender, PacketBroadcaster $broadcaster, Compressor $compressor, string $ip, int $port){
+        parent::__construct($server, $manager, $packetPool, $sender, $broadcaster, $compressor, $ip, $port);
+		$this->playerResolver = new PromiseResolver;
+	}
 
 	public function registerPacketListener(FakePlayerPacketListener $listener) : void{
 		$this->packet_listeners[spl_object_id($listener)] = $listener;
@@ -48,5 +67,32 @@ class FakePlayerNetworkSession extends NetworkSession{
 		foreach($this->packet_listeners as $listener){
 			$listener->onPacketSend($packet, $this);
 		}
+	}
+
+	protected function createPlayer(): void{
+		$getProp = function (string $name){
+			$rp = new ReflectionProperty(NetworkSession::class, $name);
+			$rp->setAccessible(true);
+			return $rp->getValue($this);
+		};
+
+		$server = $getProp('server');
+		$info = $getProp('info');
+		$authenticated = $getProp('authenticated');
+		$cachedOfflinePlayerData = $getProp('cachedOfflinePlayerData');
+
+		$server->createPlayer($this, $info, $authenticated, $cachedOfflinePlayerData)->onCompletion(
+			function (Player $player){
+				$rm = new ReflectionMethod(NetworkSession::class, 'onPlayerCreated');
+				$rm->setAccessible(true);
+				$rm->invoke($this, $player);
+				$this->playerResolver->resolve($player);
+			},
+			fn() => $this->disconnect("Player creation failed")
+		);
+	}
+
+	public function getPlayerPromise() : Promise{
+		return $this->playerResolver->getPromise();
 	}
 }


### PR DESCRIPTION
### Fixes Issues
* #21
* #27

# Problem
`Loader::addPlayer()` would oftentimes fail because it mistakenly assumes that a player object will be created after it sends a finishing `ResourcePackClientResponsePacket::STATUS_COMPLETED` message. However if the server is brand new, or hasn't generated spawn chunks yet, PocketMine-MP may potentially defer on creating the Player object way after `Loader::addPlayer()` has returned.

# Proposed Solution
Change `Load::addPlayer()`'s signature to this:
```php
Loader::addPlayer(FakePlayerInfo $info) : Promise;
```
And have `addPlayer()` return a promise that resolves with a `Player` **after** registering it as a `FakePlayer`, to be consistent with how the previous version similarly returned a `Player` after registering its corresponding `FakePlayer`.

# Justification
FakePlayer is very useful for automated testing. Capital's suite tests rely on creating a brand new PocketMine-MP instance for its tests. For FakePlayer to work in that sort of situation, it has to handle the occasions where a player isn't created immediately.